### PR TITLE
Linking errors when cmake build type is set to "Debug"

### DIFF
--- a/wmis/lib/mis/ils/local_search.cpp
+++ b/wmis/lib/mis/ils/local_search.cpp
@@ -13,6 +13,8 @@
 #include "random_functions.h"
 #include "bucket_array.h"
 
+constexpr NodeID local_search::INVALID_NODE;
+
 local_search::local_search(const MISConfig& config) {
 	sort_freenodes = config.sort_freenodes;
 }

--- a/wmis/lib/mis/ils/local_search.h
+++ b/wmis/lib/mis/ils/local_search.h
@@ -1,4 +1,4 @@
-/**
+/*
  * local_search.h
  * Purpose: Apply the local search algorithm to a maximum independent set.
  *
@@ -110,7 +110,7 @@ class local_search {
     private:
 		// insertion node of a (1,2)-swap
 		using Swap_1_2 = std::pair<NodeID, NodeID>;
-		static const NodeID INVALID_NODE = std::numeric_limits<NodeID>::max();
+		static constexpr NodeID INVALID_NODE = std::numeric_limits<NodeID>::max();
 
         // List of 1-tight neighbors of a node.
         std::vector<NodeID> onetight;

--- a/wmis/lib/mis/kernel/branch_and_reduce_algorithm.cpp
+++ b/wmis/lib/mis/kernel/branch_and_reduce_algorithm.cpp
@@ -15,7 +15,7 @@ std::streambuf* cout_handler::cout_rdbuf_backup = std::cout.rdbuf();
 std::stringstream cout_handler::buffered_output;
 int cout_handler::disable_count = 0;
 
-
+constexpr NodeID branch_and_reduce_algorithm::BRANCHING_TOKEN;
 
 branch_and_reduce_algorithm::branch_and_reduce_algorithm(graph_access& G, const MISConfig& config, bool called_from_fold)
 	: config(config), global_status(G), set_1(global_status.n), set_2(global_status.n), double_set(global_status.n * 2), buffers(2, sized_vector<NodeID>(global_status.n)) {


### PR DESCRIPTION
I run into linking errors when I compiled the project.
The CMake project was configured with `cmake  ../ -DCMAKE_BUILD_TYPE=Debug`.
The error occurs with the GNU v13 compiler on MacOS and Debian.

Linking Error:
`Undefined symbols for architecture x86_64:
  "__ZN12local_search12INVALID_NODEE", referenced from:
      __ZN12local_search16update_candidateEjjR12graph_access in local_search.cpp.o
  "__ZN27branch_and_reduce_algorithm15BRANCHING_TOKENE", referenced from:
      __ZN27branch_and_reduce_algorithm21reduce_graph_internalEv in branch_and_reduce_algorithm.cpp.o
      __ZN27branch_and_reduce_algorithm30branch_reduce_single_componentEv in branch_and_reduce_algorithm.cpp.o
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
make[3]: *** [m2s_branch_and_reduce] Error 1
make[2]: *** [CMakeFiles/m2s_branch_and_reduce.dir/all] Error 2
make[1]: *** [CMakeFiles/m2s_branch_and_reduce.dir/rule] Error 2
make: *** [m2s_branch_and_reduce] Error 2`

I was able to fix the errors by declaring the static constexpr members in the translation units.
I changed the type of INVALID_NODE in the local_search.h from `const NodeID` to `constexpr NodeID`.
Most likely these errors only occur in the Debug release due to some one-definition rule violations when compiling without NDEBUG.
The latest commit where this error does not occur is `254fd16`.