### PR TITLE
Change initialization of OnlineMIS to only read input file once

### DIFF
--- a/app/online_mis.cpp
+++ b/app/online_mis.cpp
@@ -43,7 +43,7 @@ int main(int argn, char **argv) {
 
   // Graph copy for unfolding
   graph_access fG;
-  graph_io::readGraphWeighted(fG, graph_filepath);
+  G.copy(fG);
 
   // Print setup information
   mis_log::instance()->print_graph();


### PR DESCRIPTION
Currently, OnlineMIS reads the input file twice when initializing. This is problematic when reading from a named pipe, since the graph is only available to be read once. This pull request changes the behaviour to instead only read in the graph once, and copying it instead of reading the file twice.