### PR TITLE
fix: memory leak in graph_access of wmis project

### DIFF
--- a/wmis/extern/KaHIP/lib/data_structure/graph_access.h
+++ b/wmis/extern/KaHIP/lib/data_structure/graph_access.h
@@ -447,6 +447,9 @@ inline void graph_access::set_partition_count(PartitionID count) {
 }
 
 inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
+	if(graphref != nullptr) {
+		delete graphref;
+	}
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 
@@ -467,6 +470,9 @@ inline int graph_access::build_from_metis(int n, int* xadj, int* adjncy) {
 }
 
 inline int graph_access::build_from_metis_weighted(int n, int* xadj, int* adjncy, int * vwgt, int* adjwgt) {
+	if(graphref != nullptr) {
+		delete graphref;
+	}
         graphref = new basicGraph();
         start_construction(n, xadj[n]);
 


### PR DESCRIPTION
It fixes a memory leak in the wmis/extern/KaHIP project in the build methods of the graph_access class.